### PR TITLE
[FEAT] 큐브씬 사이드 회전 구현 Feat/#8

### DIFF
--- a/Assets/13-zodiac-sign/Resources/Materials.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 749f93371a2880d49ad25996f970010c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d2b08c4481f37824fae8f2ab6190dd24
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b23ce07f66bd1794080052fcb6d2e29f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/BackMaterial.mat
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/BackMaterial.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BackMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0, g: 1, b: 0.7327335, a: 1}
+    - _Color: {r: 0, g: 1, b: 0.7327335, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &2570289226309999270
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/BackMaterial.mat.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/BackMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5bbbf475d82c84b9f8a5b4445adc0934
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/BottomMaterial.mat
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/BottomMaterial.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BottomMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.46590996, g: 1, b: 0, a: 1}
+    - _Color: {r: 0.46590996, g: 1, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &2570289226309999270
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/BottomMaterial.mat.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/BottomMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d15b28c5de6334991b3ab78ba6012059
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/DefaultMaterial.mat
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/DefaultMaterial.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DefaultMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Color: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &2570289226309999270
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/DefaultMaterial.mat.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/DefaultMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c0fdeeb8148d4e4c8c148e3b4776422
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/FrontMaterial.mat
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/FrontMaterial.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: FrontMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.078704834, g: 0, b: 1, a: 1}
+    - _Color: {r: 0.07870481, g: 0, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &2570289226309999270
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/FrontMaterial.mat.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/FrontMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c4bec150d1ea4540b9736c8f23c6d43
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/SideBackMaterial.mat
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/SideBackMaterial.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideBackMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: _SmoothnessTextureChannel
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &2570289226309999270
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/SideBackMaterial.mat.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/SideBackMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3815401ae0b64264a7899cfc7d5db8c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/SideMaterial.mat
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/SideMaterial.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 0.76640606, b: 0, a: 1}
+    - _Color: {r: 1, g: 0.76640606, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &2570289226309999270
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/SideMaterial.mat.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/SideMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7464663a9f1a436098ee97d3e1a3cd4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/TopMaterial.mat
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/TopMaterial.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TopMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 0, b: 0.061853886, a: 1}
+    - _Color: {r: 1, g: 0, b: 0.061853863, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &2570289226309999270
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/TopMaterial.mat.meta
+++ b/Assets/13-zodiac-sign/Resources/Materials/Cube/CubeBlocks/TopMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b23615a3134d1445d8e673b14db55d6a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks.meta
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c12e82a56e1139047b5b15cd251277b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block1.prefab
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block1.prefab
@@ -1,0 +1,743 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &709507980712206859
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5991770238067816232}
+  - component: {fileID: 7724750038498857964}
+  - component: {fileID: 7853993024319911115}
+  - component: {fileID: 8044650097546497807}
+  m_Layer: 0
+  m_Name: back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5991770238067816232
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709507980712206859}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0.5, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 847941958551334711}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
+--- !u!33 &7724750038498857964
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709507980712206859}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7853993024319911115
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709507980712206859}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5bbbf475d82c84b9f8a5b4445adc0934, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &8044650097546497807
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709507980712206859}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &975041787765790704
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7912421950573036672}
+  - component: {fileID: 5906390620393006496}
+  - component: {fileID: 5215193077751613233}
+  - component: {fileID: 9140684333878892006}
+  m_Layer: 0
+  m_Name: bottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7912421950573036672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975041787765790704}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
+  m_LocalPosition: {x: 0, y: -0.5, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.1, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 847941958551334711}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
+--- !u!33 &5906390620393006496
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975041787765790704}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5215193077751613233
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975041787765790704}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d15b28c5de6334991b3ab78ba6012059, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &9140684333878892006
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975041787765790704}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &3827982113748508343
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4421188434896338342}
+  - component: {fileID: 5445776179236427190}
+  - component: {fileID: 7291233690149177831}
+  - component: {fileID: 5383488087800973153}
+  m_Layer: 0
+  m_Name: sideBack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4421188434896338342
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3827982113748508343}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0.5}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 847941958551334711}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &5445776179236427190
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3827982113748508343}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7291233690149177831
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3827982113748508343}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e3815401ae0b64264a7899cfc7d5db8c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &5383488087800973153
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3827982113748508343}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5976134772573763273
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 847941958551334711}
+  - component: {fileID: 6100370180085011001}
+  - component: {fileID: 2757245874107127595}
+  - component: {fileID: 457495674465683596}
+  m_Layer: 0
+  m_Name: Block1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &847941958551334711
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5976134772573763273}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3601968778446645086}
+  - {fileID: 5991770238067816232}
+  - {fileID: 4423682471014017453}
+  - {fileID: 4421188434896338342}
+  - {fileID: 4050470110841896159}
+  - {fileID: 7912421950573036672}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6100370180085011001
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5976134772573763273}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2757245874107127595
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5976134772573763273}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5c0fdeeb8148d4e4c8c148e3b4776422, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &457495674465683596
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5976134772573763273}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &6704287650388753939
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4423682471014017453}
+  - component: {fileID: 413583919950396384}
+  - component: {fileID: 6058242207460183262}
+  - component: {fileID: 9034335934327633693}
+  m_Layer: 0
+  m_Name: side
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4423682471014017453
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6704287650388753939}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 847941958551334711}
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+--- !u!33 &413583919950396384
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6704287650388753939}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6058242207460183262
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6704287650388753939}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: f7464663a9f1a436098ee97d3e1a3cd4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &9034335934327633693
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6704287650388753939}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &6837059047698279492
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4050470110841896159}
+  - component: {fileID: 5537938439518465912}
+  - component: {fileID: 7641813611671933671}
+  - component: {fileID: 8799423233761387931}
+  m_Layer: 0
+  m_Name: top
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4050470110841896159
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6837059047698279492}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.1, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 847941958551334711}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5537938439518465912
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6837059047698279492}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7641813611671933671
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6837059047698279492}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b23615a3134d1445d8e673b14db55d6a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &8799423233761387931
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6837059047698279492}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &7030762211113317292
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3601968778446645086}
+  - component: {fileID: 7564474349257559223}
+  - component: {fileID: 8302970133998382262}
+  - component: {fileID: 3651816786867324498}
+  m_Layer: 0
+  m_Name: front
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3601968778446645086
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7030762211113317292}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.5, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 847941958551334711}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &7564474349257559223
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7030762211113317292}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8302970133998382262
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7030762211113317292}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7c4bec150d1ea4540b9736c8f23c6d43, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3651816786867324498
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7030762211113317292}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block1.prefab.meta
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bf5d1db03a2474c20a21f9c6755258be
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block2.prefab
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block2.prefab
@@ -1,0 +1,319 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1285028997497801343
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3856367906476396817}
+  - component: {fileID: 8063890025550062577}
+  - component: {fileID: 1242655061065888158}
+  - component: {fileID: 2298169259036029285}
+  m_Layer: 0
+  m_Name: top
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3856367906476396817
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285028997497801343}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.1, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7848371941099301112}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8063890025550062577
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285028997497801343}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1242655061065888158
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285028997497801343}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b23615a3134d1445d8e673b14db55d6a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &2298169259036029285
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285028997497801343}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &2517957400417168210
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7848371941099301112}
+  - component: {fileID: 46565542724214944}
+  - component: {fileID: 8945261141554679497}
+  - component: {fileID: 1625399228548771117}
+  m_Layer: 0
+  m_Name: Block2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7848371941099301112
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2517957400417168210}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7605927138622937334}
+  - {fileID: 3856367906476396817}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &46565542724214944
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2517957400417168210}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8945261141554679497
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2517957400417168210}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5c0fdeeb8148d4e4c8c148e3b4776422, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &1625399228548771117
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2517957400417168210}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &8073647710399286687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7605927138622937334}
+  - component: {fileID: 8025579836683529233}
+  - component: {fileID: 1654236038871446761}
+  - component: {fileID: 4948643873093705282}
+  m_Layer: 0
+  m_Name: front
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7605927138622937334
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8073647710399286687}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.5, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7848371941099301112}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &8025579836683529233
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8073647710399286687}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1654236038871446761
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8073647710399286687}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7c4bec150d1ea4540b9736c8f23c6d43, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4948643873093705282
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8073647710399286687}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block2.prefab.meta
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 376d63c5ebbc14e42807810c1de31264
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block3.prefab
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block3.prefab
@@ -1,0 +1,213 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3341169836317989398
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6647260899037356841}
+  - component: {fileID: 8589642414540113374}
+  - component: {fileID: 59429007504713478}
+  - component: {fileID: 4763095219372138613}
+  m_Layer: 0
+  m_Name: front
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6647260899037356841
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3341169836317989398}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.5, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1593985677547050479}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &8589642414540113374
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3341169836317989398}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &59429007504713478
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3341169836317989398}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7c4bec150d1ea4540b9736c8f23c6d43, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4763095219372138613
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3341169836317989398}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5887047140896328857
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1593985677547050479}
+  - component: {fileID: 127605670381105675}
+  - component: {fileID: 4600192280009846649}
+  - component: {fileID: 6327566756409478379}
+  m_Layer: 0
+  m_Name: Block3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1593985677547050479
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5887047140896328857}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6647260899037356841}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &127605670381105675
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5887047140896328857}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4600192280009846649
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5887047140896328857}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5c0fdeeb8148d4e4c8c148e3b4776422, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &6327566756409478379
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5887047140896328857}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block3.prefab.meta
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/Block3.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9b9272fce79844ce7a6cd2dcce04541a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/YBlock.prefab
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/YBlock.prefab
@@ -1,0 +1,743 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1479503572415274036
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8240590373664558255}
+  - component: {fileID: 482142414319673096}
+  - component: {fileID: 2334958825123455639}
+  - component: {fileID: 3492410241918457323}
+  m_Layer: 10
+  m_Name: Up
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8240590373664558255
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1479503572415274036}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.1, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4732758621972012871}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &482142414319673096
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1479503572415274036}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2334958825123455639
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1479503572415274036}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b23615a3134d1445d8e673b14db55d6a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3492410241918457323
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1479503572415274036}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1.1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1684405957102358115
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8578881849076439517}
+  - component: {fileID: 5753071659680664464}
+  - component: {fileID: 2195908765808049326}
+  - component: {fileID: 3966040667397015405}
+  m_Layer: 10
+  m_Name: Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8578881849076439517
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1684405957102358115}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4732758621972012871}
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+--- !u!33 &5753071659680664464
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1684405957102358115}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2195908765808049326
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1684405957102358115}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: f7464663a9f1a436098ee97d3e1a3cd4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3966040667397015405
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1684405957102358115}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1.1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1766856612729358009
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4732758621972012871}
+  - component: {fileID: 2216476938657899081}
+  - component: {fileID: 7794016611790743387}
+  - component: {fileID: 5490738656666253564}
+  m_Layer: 0
+  m_Name: YBlock
+  m_TagString: Block
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4732758621972012871
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1766856612729358009}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.2592487, y: 0.55, z: 1.517036}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8905481058142312238}
+  - {fileID: 1823209197296994136}
+  - {fileID: 8578881849076439517}
+  - {fileID: 8588763778694860246}
+  - {fileID: 8240590373664558255}
+  - {fileID: 2856634031942808816}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2216476938657899081
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1766856612729358009}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7794016611790743387
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1766856612729358009}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5c0fdeeb8148d4e4c8c148e3b4776422, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &5490738656666253564
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1766856612729358009}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &3168305054850532316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8905481058142312238}
+  - component: {fileID: 2490548887108713671}
+  - component: {fileID: 4129887768076639430}
+  - component: {fileID: 8703065916971152930}
+  m_Layer: 10
+  m_Name: Front
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8905481058142312238
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3168305054850532316}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.5, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4732758621972012871}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &2490548887108713671
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3168305054850532316}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4129887768076639430
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3168305054850532316}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7c4bec150d1ea4540b9736c8f23c6d43, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &8703065916971152930
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3168305054850532316}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1.1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4878227342720307835
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1823209197296994136}
+  - component: {fileID: 2403109554305770396}
+  - component: {fileID: 2780024272833021115}
+  - component: {fileID: 2724126884425432959}
+  m_Layer: 10
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1823209197296994136
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878227342720307835}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0.5, y: 0, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4732758621972012871}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
+--- !u!33 &2403109554305770396
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878227342720307835}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2780024272833021115
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878227342720307835}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5bbbf475d82c84b9f8a5b4445adc0934, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &2724126884425432959
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878227342720307835}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1.1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5179798199395149696
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2856634031942808816}
+  - component: {fileID: 1990004626684876240}
+  - component: {fileID: 147011485743249217}
+  - component: {fileID: 3796648470799099286}
+  m_Layer: 10
+  m_Name: Bottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2856634031942808816
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5179798199395149696}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
+  m_LocalPosition: {x: 0, y: -0.5, z: 0}
+  m_LocalScale: {x: 0.9, y: 0.1, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4732758621972012871}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
+--- !u!33 &1990004626684876240
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5179798199395149696}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &147011485743249217
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5179798199395149696}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d15b28c5de6334991b3ab78ba6012059, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3796648470799099286
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5179798199395149696}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1.1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &9184498943836401351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8588763778694860246}
+  - component: {fileID: 142167707272160710}
+  - component: {fileID: 3406399425640479127}
+  - component: {fileID: 62946728738453265}
+  m_Layer: 10
+  m_Name: Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8588763778694860246
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9184498943836401351}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0.5}
+  m_LocalScale: {x: 0.9, y: 0.10000001, z: 0.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4732758621972012871}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &142167707272160710
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9184498943836401351}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3406399425640479127
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9184498943836401351}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e3815401ae0b64264a7899cfc7d5db8c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &62946728738453265
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9184498943836401351}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1.1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/YBlock.prefab.meta
+++ b/Assets/13-zodiac-sign/Resources/Prefabs/Cube/CubeBlocks/YBlock.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81b0d8ae298f14b5181a250a00c88ab1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Scenes/CubeSampleScene.unity
+++ b/Assets/13-zodiac-sign/Scenes/CubeSampleScene.unity
@@ -1,0 +1,10876 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0, g: 0, b: 0, a: 0}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.627451, g: 0.627451, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!4 &21895189 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1817079717}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &29089418 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 120074044}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &29359823
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &36396229
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &45875488
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &61820281
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (86)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &65791044 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1522323611}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &69017658
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (40)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &71396743
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (74)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &81074894 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 359790064}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &89866145
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 89866146}
+  - component: {fileID: 89866149}
+  - component: {fileID: 89866148}
+  - component: {fileID: 89866147}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &89866146
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 89866145}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.35355338, y: 0.35355338, z: -0.1464466, w: 0.8535535}
+  m_LocalPosition: {x: -5, y: 8.11, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1255366122}
+  m_LocalEulerAnglesHint: {x: 45, y: 45, z: 0}
+--- !u!114 &89866147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 89866145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
+--- !u!81 &89866148
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 89866145}
+  m_Enabled: 1
+--- !u!20 &89866149
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 89866145}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!1001 &102220139
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (51)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &104609198 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2057894709}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &120074044
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (120)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &127725254 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1034414372}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &134237404
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (110)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &155238160 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1839521788}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &158150460 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 624963060}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &176920015 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 815900081}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &190487608
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &194139855
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (62)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &206620517 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 578125741}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &208246750
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (117)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &208287429 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2064566010}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &209580988
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (64)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &230218755 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1911194626}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &234868828 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1286465317}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &239151556 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1627267169}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &239400964 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1565541073}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &246015837 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1923709913}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &246492028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1643761559}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &262727401 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1638465821}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &271100218 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 665991660}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &275541131 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 406414243}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &281628516 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 737310667}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &306707115 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1970361196}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &308952293
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (119)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &309961379
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &313785809 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 102220139}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &315716092 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 61820281}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &317052212
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 317052213}
+  m_Layer: 0
+  m_Name: ----------[UI]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &317052213
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 317052212}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 705894982}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &335772829 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1028868073}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &335945227 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 553784032}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &338871127
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (41)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &345011217 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1260845820}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &349234537
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (102)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &358500450
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (85)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &359790064
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (39)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &364281650
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (111)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &368051448
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (123)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &371972478 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 71396743}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &403068562 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 338871127}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &406414243
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (88)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &419353921 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 358500450}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &419360847 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1185486097}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &426179801
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (48)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &427105582
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &436452595 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1948097015}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &449172207 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 662896137}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &453658494
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (50)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &456114580 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1601837586}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &456900489
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (108)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &458830024 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 720867868}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &461553875 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1640306053}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &468577361
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (94)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &471014898 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 308952293}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &491671059
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 491671060}
+  - component: {fileID: 491671062}
+  - component: {fileID: 491671061}
+  m_Layer: 5
+  m_Name: BattleSceneButtonText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &491671060
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491671059}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1635476663}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &491671061
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491671059}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uBC30\uD2C0 \uB9F5"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: e49882b91d030fe4fa19dcc7eaeafa8d, type: 2}
+  m_sharedMaterial: {fileID: -4739751443678697230, guid: e49882b91d030fe4fa19dcc7eaeafa8d,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 72
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &491671062
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 491671059}
+  m_CullTransparentMesh: 1
+--- !u!4 &492175360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 453658494}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &504793614 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1388927460}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &510351021
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (118)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &514098962 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 69017658}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &515255621 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1046774752}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &520212631
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (115)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &522352112
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (122)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &523653959
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (121)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &527412213 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 566394131}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &541202066
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (99)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &552832108 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 680928070}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &553784032
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (67)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &566394131
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (49)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &566882056 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2076160309}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &572511577 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1711228277}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &578125741
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (109)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &582920674 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1324825408}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &601964083
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 601964084}
+  - component: {fileID: 601964087}
+  - component: {fileID: 601964086}
+  - component: {fileID: 601964085}
+  m_Layer: 5
+  m_Name: MainMenuSceneButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &601964084
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 601964083}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2044258048}
+  m_Father: {fileID: 705894982}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 300, y: -90}
+  m_SizeDelta: {x: 480, y: 90}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &601964085
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 601964083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 601964086}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &601964086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 601964083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &601964087
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 601964083}
+  m_CullTransparentMesh: 1
+--- !u!1001 &605742193
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (58)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &608020161 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1227806456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &610075409
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (57)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &616334721
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (68)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &620662584 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1171173189}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &622535289
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &624963060
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (34)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &656880775 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1481702524}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &658943950 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 622535289}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &662896137
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (80)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &663986192
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 663986193}
+  - component: {fileID: 663986195}
+  - component: {fileID: 663986194}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &663986193
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 663986192}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.35355338, y: 0.35355338, z: -0.1464466, w: 0.8535535}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1255366122}
+  m_LocalEulerAnglesHint: {x: 45, y: 45, z: 0}
+--- !u!114 &663986194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 663986192}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!108 &663986195
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 663986192}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!1001 &665991660
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (66)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &666326512 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 523653959}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &668407208 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1971133138}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &673516631
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (61)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &680928070
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (26)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &688744356
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (81)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &692698350 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2025746189}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &694441761 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 915491916}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &704024273
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (54)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &705894981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 705894982}
+  - component: {fileID: 705894985}
+  - component: {fileID: 705894984}
+  - component: {fileID: 705894983}
+  - component: {fileID: 705894986}
+  m_Layer: 5
+  m_Name: CubeSceneCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &705894982
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705894981}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1635476663}
+  - {fileID: 601964084}
+  m_Father: {fileID: 317052213}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &705894983
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705894981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &705894984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705894981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &705894985
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705894981}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &705894986
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705894981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea151444e3954144bc5c1e09043f658e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &711268384
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (35)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &714287352 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 190487608}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &720867868
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (89)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &729381884
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &737310667
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (95)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &740738228 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1537424936}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &741141805
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 741141806}
+  m_Layer: 0
+  m_Name: ----------[System]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &741141806
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 741141805}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 760885921}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &748162532 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 673516631}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &760885920
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 760885921}
+  - component: {fileID: 760885923}
+  - component: {fileID: 760885922}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &760885921
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760885920}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 741141806}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &760885922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760885920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &760885923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760885920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &761370237 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2101254717}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &815900081
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (36)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &838197300 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 520212631}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &859452802 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 45875488}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &862622284
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (116)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &873191271 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1436567469}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &882153706
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (78)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &909352332
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (113)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &915491916
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (24)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &926859496 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 605742193}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &933530356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 933530357}
+  m_Layer: 0
+  m_Name: Bottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &933530357
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 933530356}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &935252457
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (106)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &936016965
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (83)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &945966353 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 364281650}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &954272197
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (98)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &974172762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 974172763}
+  m_Layer: 0
+  m_Name: RayStart
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &974172763
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974172762}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1255366122}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &976617894
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &976699960
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &979799416
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (96)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &982019993 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 909352332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &982771370
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (52)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1010350833 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1193200257}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1028791347
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (107)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1028868073
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1034414372
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (59)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1037661633
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (63)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1040839522
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (87)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1043261839 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 134237404}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1046774752
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1052727460
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (105)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1058331283 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2054238863}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1061312857 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 729381884}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1080818576 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 194139855}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1082403509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1082403510}
+  m_Layer: 0
+  m_Name: Front
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1082403510
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1082403509}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1089687503 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 309961379}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1099030621 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 349234537}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1105273982 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1245984257}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1105583832 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 616334721}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1111771483 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 976699960}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1116076914
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1116076915}
+  m_Layer: 0
+  m_Name: Rays
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1116076915
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1116076914}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1725808442}
+  - {fileID: 1082403510}
+  - {fileID: 1399122184}
+  - {fileID: 1826165925}
+  - {fileID: 1726481135}
+  - {fileID: 933530357}
+  m_Father: {fileID: 1652618764}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1118246499 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 541202066}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1133143717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (44)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1137612520
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (79)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1143257619 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 979799416}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1153272842 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1719147971}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1171173189
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (31)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1176773624
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (76)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1178795005
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1185486097
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (84)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1193200257
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (73)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1206393728
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (32)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1227806456
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1245984257
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (69)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1246843743 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 711268384}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1255366121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1255366122}
+  m_Layer: 0
+  m_Name: ----------[Space]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1255366122
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1255366121}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 89866146}
+  - {fileID: 663986193}
+  - {fileID: 1652618764}
+  - {fileID: 974172763}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1260845820
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (60)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1266272334
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (71)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1280287623 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 29359823}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1286465317
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (65)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1287231238 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1577874152}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1296903563 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1591696290}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1304245404 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 468577361}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1305903428 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1994848667}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1310256892 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1178795005}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1324825408
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (82)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1328367298 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 209580988}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1349444911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (101)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1352558908
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (47)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1362252348
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (28)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1366194649 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1206393728}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1368324575 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 882153706}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1376158224 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1596111984}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1388927460
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (124)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &1399122183
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1399122184}
+  m_Layer: 0
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1399122184
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399122183}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1405922892 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1266272334}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1406084322
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1410140383 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1052727460}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1436567469
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (103)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1442552922 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 862622284}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1442932583
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (29)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1455152548 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1606163453}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1469108028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1352558908}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1471418435 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 427105582}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1481702524
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (56)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1518677064 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1349444911}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1522323611
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (55)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1537424936
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (100)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1554528079 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 704024273}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1559575888 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1688934909}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1565541073
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (37)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1575195503
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1577874152
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (90)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1591696290
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1594309251 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1040839522}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1596111984
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (42)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1601837586
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (38)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1606163453
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (46)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1609576118 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 208246750}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1624729012 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2061083975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1627267169
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (43)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1630960600
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (27)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &1635476662
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1635476663}
+  - component: {fileID: 1635476666}
+  - component: {fileID: 1635476665}
+  - component: {fileID: 1635476664}
+  m_Layer: 5
+  m_Name: BattleSceneButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1635476663
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1635476662}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 491671060}
+  m_Father: {fileID: 705894982}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -300, y: -90}
+  m_SizeDelta: {x: 480, y: 90}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1635476664
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1635476662}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1635476665}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1635476665
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1635476662}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1635476666
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1635476662}
+  m_CullTransparentMesh: 1
+--- !u!1001 &1638465821
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (91)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1640306053
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (30)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1643761559
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1651612916
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (72)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &1652618763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1652618764}
+  - component: {fileID: 1652618766}
+  - component: {fileID: 1652618765}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1652618764
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1652618763}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2039829675}
+  - {fileID: 1310256892}
+  - {fileID: 208287429}
+  - {fileID: 1111771483}
+  - {fileID: 658943950}
+  - {fileID: 104609198}
+  - {fileID: 2059058071}
+  - {fileID: 21895189}
+  - {fileID: 1089687503}
+  - {fileID: 335772829}
+  - {fileID: 1471418435}
+  - {fileID: 1280287623}
+  - {fileID: 246492028}
+  - {fileID: 1296903563}
+  - {fileID: 436452595}
+  - {fileID: 1061312857}
+  - {fileID: 608020161}
+  - {fileID: 1735039797}
+  - {fileID: 714287352}
+  - {fileID: 859452802}
+  - {fileID: 515255621}
+  - {fileID: 2036876645}
+  - {fileID: 761370237}
+  - {fileID: 1559575888}
+  - {fileID: 694441761}
+  - {fileID: 306707115}
+  - {fileID: 552832108}
+  - {fileID: 1817968528}
+  - {fileID: 1996391054}
+  - {fileID: 2066530159}
+  - {fileID: 461553875}
+  - {fileID: 620662584}
+  - {fileID: 1366194649}
+  - {fileID: 1624729012}
+  - {fileID: 158150460}
+  - {fileID: 1246843743}
+  - {fileID: 176920015}
+  - {fileID: 239400964}
+  - {fileID: 456114580}
+  - {fileID: 81074894}
+  - {fileID: 514098962}
+  - {fileID: 403068562}
+  - {fileID: 1376158224}
+  - {fileID: 239151556}
+  - {fileID: 1802341844}
+  - {fileID: 155238160}
+  - {fileID: 1455152548}
+  - {fileID: 1469108028}
+  - {fileID: 1848459417}
+  - {fileID: 527412213}
+  - {fileID: 371972478}
+  - {fileID: 492175360}
+  - {fileID: 313785809}
+  - {fileID: 2046582151}
+  - {fileID: 572511577}
+  - {fileID: 1554528079}
+  - {fileID: 65791044}
+  - {fileID: 656880775}
+  - {fileID: 2142134781}
+  - {fileID: 926859496}
+  - {fileID: 127725254}
+  - {fileID: 345011217}
+  - {fileID: 748162532}
+  - {fileID: 1080818576}
+  - {fileID: 1712021271}
+  - {fileID: 1328367298}
+  - {fileID: 234868828}
+  - {fileID: 271100218}
+  - {fileID: 335945227}
+  - {fileID: 1105583832}
+  - {fileID: 1105273982}
+  - {fileID: 566882056}
+  - {fileID: 1405922892}
+  - {fileID: 2068086208}
+  - {fileID: 1010350833}
+  - {fileID: 1118246499}
+  - {fileID: 262727401}
+  - {fileID: 230218755}
+  - {fileID: 1984344715}
+  - {fileID: 1305903428}
+  - {fileID: 1368324575}
+  - {fileID: 1784553669}
+  - {fileID: 449172207}
+  - {fileID: 2140256421}
+  - {fileID: 582920674}
+  - {fileID: 1807201819}
+  - {fileID: 419360847}
+  - {fileID: 419353921}
+  - {fileID: 315716092}
+  - {fileID: 1594309251}
+  - {fileID: 275541131}
+  - {fileID: 458830024}
+  - {fileID: 1287231238}
+  - {fileID: 1153272842}
+  - {fileID: 1721132355}
+  - {fileID: 1304245404}
+  - {fileID: 281628516}
+  - {fileID: 1143257619}
+  - {fileID: 1058331283}
+  - {fileID: 2117888356}
+  - {fileID: 838197300}
+  - {fileID: 1609576118}
+  - {fileID: 740738228}
+  - {fileID: 1518677064}
+  - {fileID: 1099030621}
+  - {fileID: 873191271}
+  - {fileID: 692698350}
+  - {fileID: 1410140383}
+  - {fileID: 1784739761}
+  - {fileID: 1867945623}
+  - {fileID: 1903336198}
+  - {fileID: 206620517}
+  - {fileID: 1043261839}
+  - {fileID: 945966353}
+  - {fileID: 246015837}
+  - {fileID: 982019993}
+  - {fileID: 668407208}
+  - {fileID: 1442552922}
+  - {fileID: 1984211706}
+  - {fileID: 471014898}
+  - {fileID: 29089418}
+  - {fileID: 666326512}
+  - {fileID: 1841214607}
+  - {fileID: 1797524808}
+  - {fileID: 504793614}
+  - {fileID: 1116076915}
+  m_Father: {fileID: 1255366122}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1652618765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1652618763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3bb1a2c6732e771468d45b9c5d493810, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1652618766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1652618763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30e8306c3115754479fa9a174dc34231, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tUp: {fileID: 1725808442}
+  tDown: {fileID: 933530357}
+  tLeft: {fileID: 1726481135}
+  tRight: {fileID: 1826165925}
+  tFront: {fileID: 1082403510}
+  tBack: {fileID: 1399122184}
+  emptyGO: {fileID: 974172762}
+--- !u!1001 &1688934909
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1711228277
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (53)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1712021271 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1037661633}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1719147971
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (92)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1721132355 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1761296617}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1725808441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1725808442}
+  m_Layer: 0
+  m_Name: Up
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1725808442
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725808441}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1726481134
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1726481135}
+  m_Layer: 0
+  m_Name: Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1726481135
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1726481134}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1735039797 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1406084322}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1761296617
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (93)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1784553669 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1137612520}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1784739761 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 935252457}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1797524808 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 368051448}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1802341844 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1133143717}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1807201819 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 936016965}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1817079717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1817968528 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1630960600}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1826165924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1826165925}
+  m_Layer: 0
+  m_Name: Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1826165925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1826165924}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1839521788
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (45)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1841214607 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 522352112}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1848459417 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 426179801}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1867945623 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1028791347}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1903336198 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 456900489}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1911194626
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (75)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1923709913
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (112)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1948097015
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1970361196
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (25)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1971133138
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (114)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1984211706 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 510351021}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1984344715 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1176773624}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1994848667
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (77)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1996391054 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1362252348}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2025746189
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (104)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &2036876645 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 36396229}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2039829675 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 976617894}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2044258047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2044258048}
+  - component: {fileID: 2044258050}
+  - component: {fileID: 2044258049}
+  m_Layer: 5
+  m_Name: MainMenuSceneButtonText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2044258048
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044258047}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 601964084}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2044258049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044258047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uBA54\uC778 \uBA54\uB274"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: e49882b91d030fe4fa19dcc7eaeafa8d, type: 2}
+  m_sharedMaterial: {fileID: -4739751443678697230, guid: e49882b91d030fe4fa19dcc7eaeafa8d,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 72
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2044258050
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044258047}
+  m_CullTransparentMesh: 1
+--- !u!4 &2046582151 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 982771370}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2054238863
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (97)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &2057894709
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &2059058071 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1575195503}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2061083975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (33)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &2064566010
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &2066530159 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1442932583}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2068086208 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1651612916}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2076160309
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (70)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &2101254717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &2117888356 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 954272197}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2140256421 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 688744356}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2142134781 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 610075409}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 741141806}
+  - {fileID: 1255366122}
+  - {fileID: 317052213}

--- a/Assets/13-zodiac-sign/Scenes/CubeSampleScene.unity.meta
+++ b/Assets/13-zodiac-sign/Scenes/CubeSampleScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 192848827be325b45abe6c91805b5580
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Scenes/CubeScene.unity
+++ b/Assets/13-zodiac-sign/Scenes/CubeScene.unity
@@ -123,6 +123,438 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!4 &21895189 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1817079717}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &29089418 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 120074044}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &29359823
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &36396229
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &45875488
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &61820281
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (86)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &65791044 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1522323611}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &69017658
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (40)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &71396743
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (74)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &81074894 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 359790064}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &89866145
 GameObject:
   m_ObjectHideFlags: 0
@@ -150,13 +582,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 89866145}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalRotation: {x: 0.35355338, y: 0.35355338, z: -0.1464466, w: 0.8535535}
+  m_LocalPosition: {x: -5, y: 8.11, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1255366122}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 45, y: 45, z: 0}
 --- !u!114 &89866147
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -260,6 +692,738 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!1001 &102220139
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (51)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &104609198 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2057894709}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &120074044
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (120)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &127725254 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1034414372}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &134237404
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (110)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &155238160 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1839521788}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &158150460 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 624963060}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &176920015 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 815900081}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &190487608
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &194139855
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (62)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &206620517 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 578125741}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &208246750
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (117)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &208287429 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2064566010}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &209580988
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (64)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &230218755 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1911194626}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &234868828 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1286465317}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &239151556 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1627267169}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &239400964 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1565541073}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &246015837 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1923709913}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &246492028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1643761559}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &262727401 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1638465821}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &271100218 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 665991660}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &275541131 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 406414243}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &281628516 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 737310667}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &306707115 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1970361196}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &308952293
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (119)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &309961379
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &313785809 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 102220139}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &315716092 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 61820281}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &317052212
 GameObject:
   m_ObjectHideFlags: 0
@@ -292,6 +1456,900 @@ Transform:
   - {fileID: 705894982}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &335772829 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1028868073}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &335945227 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 553784032}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &338871127
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (41)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &345011217 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1260845820}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &349234537
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (102)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &358500450
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (85)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &359790064
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (39)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &364281650
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (111)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &368051448
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (123)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &371972478 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 71396743}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &403068562 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 338871127}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &406414243
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (88)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &419353921 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 358500450}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &419360847 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1185486097}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &426179801
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (48)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &427105582
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &436452595 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1948097015}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &449172207 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 662896137}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &453658494
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (50)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &456114580 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1601837586}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &456900489
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (108)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &458830024 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 720867868}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &461553875 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1640306053}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &468577361
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (94)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &471014898 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 308952293}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &491671059
 GameObject:
   m_ObjectHideFlags: 0
@@ -427,6 +2485,604 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 491671059}
   m_CullTransparentMesh: 1
+--- !u!4 &492175360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 453658494}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &504793614 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1388927460}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &510351021
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (118)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &514098962 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 69017658}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &515255621 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1046774752}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &520212631
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (115)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &522352112
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (122)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &523653959
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (121)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &527412213 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 566394131}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &541202066
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (99)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &552832108 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 680928070}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &553784032
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (67)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &566394131
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (49)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &566882056 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2076160309}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &572511577 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1711228277}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &578125741
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (109)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &582920674 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1324825408}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &601964083
 GameObject:
   m_ObjectHideFlags: 0
@@ -548,6 +3204,438 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 601964083}
   m_CullTransparentMesh: 1
+--- !u!1001 &605742193
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (58)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &608020161 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1227806456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &610075409
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (57)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &616334721
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (68)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &620662584 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1171173189}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &622535289
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &624963060
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (34)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &656880775 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1481702524}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &658943950 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 622535289}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &662896137
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (80)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
 --- !u!1 &663986192
 GameObject:
   m_ObjectHideFlags: 0
@@ -666,6 +3754,370 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1001 &665991660
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (66)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &666326512 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 523653959}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &668407208 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1971133138}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &673516631
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (61)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &680928070
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (26)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &688744356
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (81)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &692698350 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2025746189}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &694441761 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 915491916}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &704024273
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (54)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
 --- !u!1 &705894981
 GameObject:
   m_ObjectHideFlags: 0
@@ -782,6 +4234,290 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea151444e3954144bc5c1e09043f658e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &711268384
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (35)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &714287352 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 190487608}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &720867868
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (89)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &729381884
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &737310667
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (95)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &740738228 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1537424936}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &741141805
 GameObject:
   m_ObjectHideFlags: 0
@@ -814,6 +4550,12 @@ Transform:
   - {fileID: 760885921}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &748162532 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 673516631}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &760885920
 GameObject:
   m_ObjectHideFlags: 0
@@ -882,6 +4624,2234 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
+--- !u!4 &761370237 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2101254717}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &815900081
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (36)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &838197300 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 520212631}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &859452802 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 45875488}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &862622284
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (116)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &873191271 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1436567469}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &882153706
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (78)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &909352332
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (113)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &915491916
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (24)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &926859496 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 605742193}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &933530356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 933530357}
+  m_Layer: 0
+  m_Name: Bottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &933530357
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 933530356}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &935252457
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (106)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &936016965
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (83)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &945966353 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 364281650}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &954272197
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (98)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &974172762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 974172763}
+  m_Layer: 0
+  m_Name: RayStart
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &974172763
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974172762}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1255366122}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &976617894
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &976699960
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &979799416
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (96)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &982019993 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 909352332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &982771370
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (52)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1010350833 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1193200257}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1028791347
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (107)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1028868073
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1034414372
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (59)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1037661633
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (63)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1040839522
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (87)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1043261839 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 134237404}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1046774752
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1052727460
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (105)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1058331283 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2054238863}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1061312857 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 729381884}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1080818576 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 194139855}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1082403509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1082403510}
+  m_Layer: 0
+  m_Name: Front
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1082403510
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1082403509}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1089687503 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 309961379}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1099030621 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 349234537}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1105273982 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1245984257}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1105583832 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 616334721}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1111771483 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 976699960}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1116076914
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1116076915}
+  m_Layer: 0
+  m_Name: Rays
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1116076915
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1116076914}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1725808442}
+  - {fileID: 1082403510}
+  - {fileID: 1399122184}
+  - {fileID: 1826165925}
+  - {fileID: 1726481135}
+  - {fileID: 933530357}
+  m_Father: {fileID: 1652618764}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1118246499 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 541202066}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1133143717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (44)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1137612520
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (79)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1143257619 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 979799416}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1153272842 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1719147971}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1171173189
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (31)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1176773624
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (76)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1178795005
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1185486097
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (84)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1193200257
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (73)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1206393728
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (32)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1227806456
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1245984257
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (69)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1246843743 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 711268384}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1255366121
 GameObject:
   m_ObjectHideFlags: 0
@@ -911,11 +6881,1739 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1699485376}
   - {fileID: 89866146}
   - {fileID: 663986193}
+  - {fileID: 1652618764}
+  - {fileID: 974172763}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1260845820
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (60)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1266272334
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (71)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1280287623 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 29359823}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1286465317
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (65)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1287231238 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1577874152}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1296903563 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1591696290}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1304245404 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 468577361}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1305903428 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1994848667}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1310256892 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1178795005}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1324825408
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (82)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1328367298 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 209580988}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1349444911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (101)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1352558908
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (47)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1362252348
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (28)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1366194649 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1206393728}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1368324575 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 882153706}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1376158224 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1596111984}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1388927460
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (124)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &1399122183
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1399122184}
+  m_Layer: 0
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1399122184
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399122183}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1405922892 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1266272334}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1406084322
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1410140383 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1052727460}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1436567469
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (103)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1442552922 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 862622284}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1442932583
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (29)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1455152548 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1606163453}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1469108028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1352558908}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1471418435 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 427105582}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1481702524
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (56)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1518677064 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1349444911}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1522323611
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (55)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1537424936
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (100)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1554528079 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 704024273}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1559575888 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1688934909}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1565541073
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (37)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1575195503
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1577874152
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (90)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1591696290
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1594309251 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1040839522}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1596111984
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (42)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1601837586
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (38)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1606163453
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (46)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1609576118 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 208246750}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1624729012 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 2061083975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1627267169
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (43)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1630960600
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (27)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
 --- !u!1 &1635476662
 GameObject:
   m_ObjectHideFlags: 0
@@ -1037,7 +8735,279 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1635476662}
   m_CullTransparentMesh: 1
---- !u!1 &1699485375
+--- !u!1001 &1638465821
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (91)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1640306053
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (30)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1643761559
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1651612916
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (72)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1 &1652618763
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1045,10 +9015,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1699485376}
-  - component: {fileID: 1699485379}
-  - component: {fileID: 1699485378}
-  - component: {fileID: 1699485377}
+  - component: {fileID: 1652618764}
+  - component: {fileID: 1652618766}
+  - component: {fileID: 1652618765}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -1056,92 +9025,1263 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1699485376
+--- !u!4 &1652618764
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1699485375}
+  m_GameObject: {fileID: 1652618763}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 2039829675}
+  - {fileID: 1310256892}
+  - {fileID: 208287429}
+  - {fileID: 1111771483}
+  - {fileID: 658943950}
+  - {fileID: 104609198}
+  - {fileID: 2059058071}
+  - {fileID: 21895189}
+  - {fileID: 1089687503}
+  - {fileID: 335772829}
+  - {fileID: 1471418435}
+  - {fileID: 1280287623}
+  - {fileID: 246492028}
+  - {fileID: 1296903563}
+  - {fileID: 436452595}
+  - {fileID: 1061312857}
+  - {fileID: 608020161}
+  - {fileID: 1735039797}
+  - {fileID: 714287352}
+  - {fileID: 859452802}
+  - {fileID: 515255621}
+  - {fileID: 2036876645}
+  - {fileID: 761370237}
+  - {fileID: 1559575888}
+  - {fileID: 694441761}
+  - {fileID: 306707115}
+  - {fileID: 552832108}
+  - {fileID: 1817968528}
+  - {fileID: 1996391054}
+  - {fileID: 2066530159}
+  - {fileID: 461553875}
+  - {fileID: 620662584}
+  - {fileID: 1366194649}
+  - {fileID: 1624729012}
+  - {fileID: 158150460}
+  - {fileID: 1246843743}
+  - {fileID: 176920015}
+  - {fileID: 239400964}
+  - {fileID: 456114580}
+  - {fileID: 81074894}
+  - {fileID: 514098962}
+  - {fileID: 403068562}
+  - {fileID: 1376158224}
+  - {fileID: 239151556}
+  - {fileID: 1802341844}
+  - {fileID: 155238160}
+  - {fileID: 1455152548}
+  - {fileID: 1469108028}
+  - {fileID: 1848459417}
+  - {fileID: 527412213}
+  - {fileID: 371972478}
+  - {fileID: 492175360}
+  - {fileID: 313785809}
+  - {fileID: 2046582151}
+  - {fileID: 572511577}
+  - {fileID: 1554528079}
+  - {fileID: 65791044}
+  - {fileID: 656880775}
+  - {fileID: 2142134781}
+  - {fileID: 926859496}
+  - {fileID: 127725254}
+  - {fileID: 345011217}
+  - {fileID: 748162532}
+  - {fileID: 1080818576}
+  - {fileID: 1712021271}
+  - {fileID: 1328367298}
+  - {fileID: 234868828}
+  - {fileID: 271100218}
+  - {fileID: 335945227}
+  - {fileID: 1105583832}
+  - {fileID: 1105273982}
+  - {fileID: 566882056}
+  - {fileID: 1405922892}
+  - {fileID: 2068086208}
+  - {fileID: 1010350833}
+  - {fileID: 1118246499}
+  - {fileID: 262727401}
+  - {fileID: 230218755}
+  - {fileID: 1984344715}
+  - {fileID: 1305903428}
+  - {fileID: 1368324575}
+  - {fileID: 1784553669}
+  - {fileID: 449172207}
+  - {fileID: 2140256421}
+  - {fileID: 582920674}
+  - {fileID: 1807201819}
+  - {fileID: 419360847}
+  - {fileID: 419353921}
+  - {fileID: 315716092}
+  - {fileID: 1594309251}
+  - {fileID: 275541131}
+  - {fileID: 458830024}
+  - {fileID: 1287231238}
+  - {fileID: 1153272842}
+  - {fileID: 1721132355}
+  - {fileID: 1304245404}
+  - {fileID: 281628516}
+  - {fileID: 1143257619}
+  - {fileID: 1058331283}
+  - {fileID: 2117888356}
+  - {fileID: 838197300}
+  - {fileID: 1609576118}
+  - {fileID: 740738228}
+  - {fileID: 1518677064}
+  - {fileID: 1099030621}
+  - {fileID: 873191271}
+  - {fileID: 692698350}
+  - {fileID: 1410140383}
+  - {fileID: 1784739761}
+  - {fileID: 1867945623}
+  - {fileID: 1903336198}
+  - {fileID: 206620517}
+  - {fileID: 1043261839}
+  - {fileID: 945966353}
+  - {fileID: 246015837}
+  - {fileID: 982019993}
+  - {fileID: 668407208}
+  - {fileID: 1442552922}
+  - {fileID: 1984211706}
+  - {fileID: 471014898}
+  - {fileID: 29089418}
+  - {fileID: 666326512}
+  - {fileID: 1841214607}
+  - {fileID: 1797524808}
+  - {fileID: 504793614}
+  - {fileID: 1116076915}
   m_Father: {fileID: 1255366122}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &1699485377
-BoxCollider:
+--- !u!114 &1652618765
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1699485375}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
+  m_GameObject: {fileID: 1652618763}
   m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1699485378
-MeshRenderer:
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3bb1a2c6732e771468d45b9c5d493810, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1652618766
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1699485375}
+  m_GameObject: {fileID: 1652618763}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1699485379
-MeshFilter:
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30e8306c3115754479fa9a174dc34231, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tUp: {fileID: 1725808442}
+  tDown: {fileID: 933530357}
+  tLeft: {fileID: 1726481135}
+  tRight: {fileID: 1826165925}
+  tFront: {fileID: 1082403510}
+  tBack: {fileID: 1399122184}
+  emptyGO: {fileID: 974172762}
+--- !u!1001 &1688934909
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1711228277
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (53)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1712021271 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1037661633}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1719147971
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (92)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1721132355 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1761296617}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1725808441
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1699485375}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1725808442}
+  m_Layer: 0
+  m_Name: Up
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1725808442
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725808441}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1726481134
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1726481135}
+  m_Layer: 0
+  m_Name: Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1726481135
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1726481134}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1735039797 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1406084322}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1761296617
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (93)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1784553669 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1137612520}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1784739761 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 935252457}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1797524808 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 368051448}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1802341844 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1133143717}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1807201819 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 936016965}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1817079717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1817968528 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1630960600}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1826165924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1826165925}
+  m_Layer: 0
+  m_Name: Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 7148428337604731935, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1826165925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1826165924}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1116076915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1839521788
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (45)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1841214607 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 522352112}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1848459417 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 426179801}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1867945623 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1028791347}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1903336198 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 456900489}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1911194626
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (75)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1923709913
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (112)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1948097015
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1970361196
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (25)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &1971133138
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (114)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1984211706 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 510351021}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1984344715 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1176773624}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1994848667
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (77)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &1996391054 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1362252348}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2025746189
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (104)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &2036876645 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 36396229}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2039829675 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 976617894}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2044258047
 GameObject:
   m_ObjectHideFlags: 0
@@ -1277,6 +10417,456 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2044258047}
   m_CullTransparentMesh: 1
+--- !u!4 &2046582151 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 982771370}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2054238863
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (97)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &2057894709
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &2059058071 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1575195503}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2061083975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (33)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &2064566010
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &2066530159 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1442932583}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2068086208 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1651612916}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2076160309
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (70)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!1001 &2101254717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1652618764}
+    m_Modifications:
+    - target: {fileID: 1766856612729358009, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: YBlock (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81b0d8ae298f14b5181a250a00c88ab1, type: 3}
+--- !u!4 &2117888356 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 954272197}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2140256421 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 688744356}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2142134781 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4732758621972012871, guid: 81b0d8ae298f14b5181a250a00c88ab1,
+    type: 3}
+  m_PrefabInstance: {fileID: 610075409}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/13-zodiac-sign/Scripts/CubeScripts.meta
+++ b/Assets/13-zodiac-sign/Scripts/CubeScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26151de31bdb0554195435d87540ea5d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Scripts/CubeScripts/ReadCube.cs
+++ b/Assets/13-zodiac-sign/Scripts/CubeScripts/ReadCube.cs
@@ -94,9 +94,8 @@ public class ReadCube : MonoBehaviour
         foreach (GameObject rayStart in rayStarts)
         {
             Vector3 ray = rayStart.transform.position;
-            RaycastHit[] hits;
-
-            hits = Physics.RaycastAll(ray, rayTransform.forward, Mathf.Infinity);
+            RaycastHit[] hits = new RaycastHit[126];
+            Physics.RaycastNonAlloc(ray, rayTransform.forward, hits, 126); 
 
             if (hits.Length > 0)
             {
@@ -104,7 +103,7 @@ public class ReadCube : MonoBehaviour
                 
                 foreach (RaycastHit hit in hits)
                 {
-                    if (hit.collider.gameObject.CompareTag(tagName))
+                    if (hit.collider != null && hit.collider.gameObject.CompareTag(tagName))
                     {
                         Debug.DrawRay(ray, rayTransform.forward * hit.distance, Color.red);
                         newList.Add(hit.collider.gameObject);

--- a/Assets/13-zodiac-sign/Scripts/CubeScripts/ReadCube.cs
+++ b/Assets/13-zodiac-sign/Scripts/CubeScripts/ReadCube.cs
@@ -19,7 +19,6 @@ public class ReadCube : MonoBehaviour
     private List<GameObject> leftRays = new List<GameObject>();
     private List<GameObject> rightRays = new List<GameObject>();   
 
-    private int layerMask = 1 << 25; // 현재 면의 25개의 위치
     private string tagName = "Block";
     RotateCube rotateCube;
     public GameObject emptyGO;

--- a/Assets/13-zodiac-sign/Scripts/CubeScripts/ReadCube.cs
+++ b/Assets/13-zodiac-sign/Scripts/CubeScripts/ReadCube.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ReadCube : MonoBehaviour
+{
+    public Transform tUp;
+    public Transform tDown;
+    public Transform tLeft;
+    public Transform tRight;
+    public Transform tFront;
+    public Transform tBack;
+
+    private List<GameObject> frontRays = new List<GameObject>();
+    private List<GameObject> backRays = new List<GameObject>();
+    private List<GameObject> upRays = new List<GameObject>();
+    private List<GameObject> downRays = new List<GameObject>();
+    private List<GameObject> leftRays = new List<GameObject>();
+    private List<GameObject> rightRays = new List<GameObject>();   
+
+    private int layerMask = 1 << 25; // 현재 면의 25개의 위치
+    private string tagName = "Block";
+    RotateCube rotateCube;
+    public GameObject emptyGO;
+       
+    // Start is called before the first frame update
+    void Start()
+    {
+        SetRayTransforms();
+
+        rotateCube = FindObjectOfType<RotateCube>();
+        ReadState();
+        RotateCube.started = true;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+    }
+
+    public void ReadState()
+    {
+        // RayCaseAll에서 감지된 모든 블록들의 배열을 가져오기
+        // 어떤 색의 면이 어디에 있는지 알 수 있게 됨
+        rotateCube.up = ReadFace(upRays, tUp);
+        rotateCube.down = ReadFace(downRays, tDown);
+        rotateCube.left = ReadFace(leftRays, tLeft);
+        rotateCube.right = ReadFace(rightRays, tRight);
+        rotateCube.front = ReadFace(frontRays, tFront);
+        rotateCube.back = ReadFace(backRays, tBack);
+    }
+
+
+    void SetRayTransforms()
+    {
+        // Ray 위치에서 큐브의 중앙으로 RayCastAll을 하기
+        upRays = BuildRays(tUp, new Vector3(90, 90, 0));
+        downRays = BuildRays(tDown, new Vector3(270, 90, 0));
+        leftRays = BuildRays(tLeft, new Vector3(0, 180, 0));
+        rightRays = BuildRays(tRight, new Vector3(0, 0, 0));
+        frontRays = BuildRays(tFront, new Vector3(0, 90, 0));
+        backRays = BuildRays(tBack, new Vector3(0, 270, 0));
+    }
+
+
+    List<GameObject> BuildRays(Transform rayTransform, Vector3 direction)
+    {
+        // 우리는 맵의 정보를 0~24 번으로 정의
+        int rayCount = 0;
+        List<GameObject> rays = new List<GameObject>();
+
+        for (int y = 2; y > -3; y--)
+        {
+            for (int x = -2; x < 3; x++)
+            {
+                Vector3 startPos = new Vector3( rayTransform.localPosition.x + x,
+                                                rayTransform.localPosition.y + y,
+                                                rayTransform.localPosition.z);
+                GameObject rayStart = Instantiate(emptyGO, startPos, Quaternion.identity, rayTransform);
+                rayStart.name = rayCount.ToString();
+                rays.Add(rayStart);
+                rayCount++;
+            }
+        }
+        rayTransform.localRotation = Quaternion.Euler(direction);
+        return rays;
+
+    }
+
+    public List<List<GameObject>> ReadFace(List<GameObject> rayStarts, Transform rayTransform)
+    {
+        List<List<GameObject>> facesHit = new List<List<GameObject>>();
+
+        foreach (GameObject rayStart in rayStarts)
+        {
+            Vector3 ray = rayStart.transform.position;
+            RaycastHit[] hits;
+
+            hits = Physics.RaycastAll(ray, rayTransform.forward, Mathf.Infinity);
+
+            if (hits.Length > 0)
+            {
+                List<GameObject> newList = new List<GameObject>();
+                
+                foreach (RaycastHit hit in hits)
+                {
+                    if (hit.collider.gameObject.CompareTag(tagName))
+                    {
+                        Debug.DrawRay(ray, rayTransform.forward * hit.distance, Color.red);
+                        newList.Add(hit.collider.gameObject);
+                        Debug.Log(hit.collider.gameObject.name);
+                    }
+                }
+
+                facesHit.Add(newList);
+            }
+            else
+            {
+                Debug.DrawRay(ray, rayTransform.forward * 1000, Color.green); // 충돌하지 않았을 경우의 Ray 표시
+            }
+            
+        }
+        return facesHit;
+    }
+
+}
+
+

--- a/Assets/13-zodiac-sign/Scripts/CubeScripts/ReadCube.cs.meta
+++ b/Assets/13-zodiac-sign/Scripts/CubeScripts/ReadCube.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30e8306c3115754479fa9a174dc34231
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Scripts/CubeScripts/RotateCube.cs
+++ b/Assets/13-zodiac-sign/Scripts/CubeScripts/RotateCube.cs
@@ -1,0 +1,126 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+public class RotateCube : MonoBehaviour
+{
+    // sides
+    public List<List<GameObject>> front = new List<List<GameObject>>();
+    public List<List<GameObject>> back = new List<List<GameObject>>();
+    public List<List<GameObject>> up = new List<List<GameObject>>();
+    public List<List<GameObject>> down = new List<List<GameObject>>();
+    public List<List<GameObject>> left = new List<List<GameObject>>();
+    public List<List<GameObject>> right = new List<List<GameObject>>();
+
+    public static bool autoRotating = false;
+    public static bool started = false;
+    
+    float rotSpeed = 100f;
+    private Vector3 centerPoint; // 중심점
+    private float rotationAmount = 90f; // 회전할 각도
+    private float rotationSpeedPerMinute = 90f; // 회전에 소요될 시간 (초)
+    
+    // Start is called before the first frame update
+    void Start()
+    {
+    
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Alpha1))
+        {
+            PressKey(front, 0);
+        }
+        if (Input.GetKeyDown(KeyCode.Alpha2))
+        {
+            PressKey(front, 1);
+        }
+        if (Input.GetKeyDown(KeyCode.Alpha3))
+        {
+            PressKey(front, 2);
+        }
+        if (Input.GetKeyDown(KeyCode.Alpha4))
+        { 
+            PressKey(front, 3);
+        }
+        if (Input.GetKeyDown(KeyCode.Alpha5))
+        {
+            PressKey(front, 4);
+        }
+        if (Input.GetKeyDown(KeyCode.Q))
+        {
+            SwitchRotateDirection();
+        }
+    }
+
+    public void SwitchRotateDirection()
+    {
+        if (rotationAmount == 90f)
+        {
+            rotationAmount = -90f;
+        }
+        else
+        {
+            rotationAmount = 90f;
+        }
+    }
+    
+    public void PressKey(List<List<GameObject>> lists ,int k)
+    {
+        CalculateCenterPoint(lists, k);
+        StartCoroutine(RotateObjectsAroundCenter(lists ,rotationAmount, k)); // 90도, 2초 동안 회전
+    }
+    
+    public void CalculateCenterPoint(List<List<GameObject>> list, int k)
+    {
+        int idx = 0;
+        if (list.Count == 0) return;
+        centerPoint = new Vector3(0,0,0);
+
+        Vector3 sum = Vector3.zero;
+        foreach (List<GameObject> objs in list)
+        {
+            foreach (GameObject obj in objs)
+            {
+                if (idx % 5 == k)
+                {
+                    sum += obj.transform.position;
+                }
+                idx++;
+            }
+        }
+        centerPoint = sum / list.Count;
+    }
+
+    public IEnumerator RotateObjectsAroundCenter(List<List<GameObject>> lists, float totalRotation, int l)
+    {
+        float currentRotation = 0;
+        float direction = Mathf.Sign(totalRotation); // 회전 방향
+
+        while ((direction == 1 && currentRotation < totalRotation) || (direction == -1 && currentRotation > totalRotation))
+        {
+            float step = rotationSpeedPerMinute * Time.deltaTime; // 이번 업데이트에서 회전해야 할 각도
+            float rotationThisFrame = direction * Mathf.Min(Mathf.Abs(step), Mathf.Abs(totalRotation - currentRotation));
+            int i = 0;
+            foreach ( List<GameObject> k in lists)
+            {
+                foreach (GameObject m in k)
+                {
+                    if (i % 5 == l)
+                    {
+                        m.transform.RotateAround(centerPoint, Vector3.left, rotationThisFrame);
+                    }
+                    i++;
+                }
+            }
+            currentRotation += direction * Mathf.Abs(rotationThisFrame); // 현재 회전량 업데이트
+            yield return null;
+        }
+        
+        
+    }
+}

--- a/Assets/13-zodiac-sign/Scripts/CubeScripts/RotateCube.cs
+++ b/Assets/13-zodiac-sign/Scripts/CubeScripts/RotateCube.cs
@@ -17,7 +17,6 @@ public class RotateCube : MonoBehaviour
     public static bool autoRotating = false;
     public static bool started = false;
     
-    float rotSpeed = 100f;
     private Vector3 centerPoint; // 중심점
     private float rotationAmount = 90f; // 회전할 각도
     private float rotationSpeedPerMinute = 90f; // 회전에 소요될 시간 (초)

--- a/Assets/13-zodiac-sign/Scripts/CubeScripts/RotateCube.cs.meta
+++ b/Assets/13-zodiac-sign/Scripts/CubeScripts/RotateCube.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3bb1a2c6732e771468d45b9c5d493810
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/13-zodiac-sign/Scripts/UIScripts/TempUI.cs
+++ b/Assets/13-zodiac-sign/Scripts/UIScripts/TempUI.cs
@@ -36,7 +36,6 @@ namespace _13_zodiac_sign.Scripts.UIScripts
                     });
                 }
             }
-            throw new NotImplementedException();
         }
     }
 }

--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f011ca0c2ed0a5479a4536223506dc1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes.meta
+++ b/Assets/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1bd594105a707eb4182146b58432f333
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.collab-proxy": "2.2.0",
+    "com.unity.device-simulator.devices": "1.0.0",
     "com.unity.ide.rider": "3.0.27",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -22,6 +22,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.device-simulator.devices": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ext.nunit": {
       "version": "1.0.6",
       "depth": 1,

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Block
   layers:
   - Default
   - TransparentFX
@@ -15,7 +16,7 @@ TagManager:
   - 
   - 
   - 
-  - 
+  - Faces
   - 
   - 
   - 


### PR DESCRIPTION
## 작업한 내용
- https://github.com/alttabsoft/13-zodiac-signs/issues/8
- 큐브 회전 구현
- 큐브 에셋 배치
- 6개의 면의 위치 정보 검출
    RaycastAll로 검출된 GameObject 들을 List<List<GameObject>> 2차원 배열로 관리

## 참고 사항
- alphanumeric keyboard 1~5번을 클릭하면 윗 면의 각 줄이 회전합니다
- KeyBoard Q를 클릭하면 회전 방향을 바꿀 수 있습니다
- 임시 에셋이 적용되어 있어 디자인 에셋이 완성되면 추가 리팩이 필요합니다. 

## 스크린샷
|기능|스크린샷|
|:--:|:--:|
|큐브 윗면의  각 줄 회전|<img src = "https://github.com/alttabsoft/13-zodiac-signs/assets/54494793/a761f93e-f438-4351-a05e-e30af36b03c4">
||<img src = "">

## 관련 이슈

- Resolved: #
