### PR TITLE
[Fix] 플레이어 점프 이슈 해결

### DIFF
--- a/Assets/Scenes/Rubik_TempAsset/Scripts/CharacterJump.cs
+++ b/Assets/Scenes/Rubik_TempAsset/Scripts/CharacterJump.cs
@@ -26,10 +26,12 @@ public class CharacterJump : MonoBehaviour
     }
     private IEnumerator PlayerJump()
     {
+        var jumpWeight = 0.03f;
+        
         while (jumpCount < 10)
         {
             jumpCount++;
-            playerBodyCharacterController.Move(new Vector3(0,0,2) * Time.deltaTime);
+            playerBodyCharacterController.Move(new Vector3(0,0,2) * jumpWeight);
             yield return new WaitForFixedUpdate();
         }
         jumpCount = 0;
@@ -37,7 +39,7 @@ public class CharacterJump : MonoBehaviour
         while (jumpCount < 10)
         {
             jumpCount++;
-            playerBodyCharacterController.Move(new Vector3(0,0,-2) * Time.deltaTime);
+            playerBodyCharacterController.Move(new Vector3(0,0,-2) * jumpWeight);
             yield return new WaitForFixedUpdate();
         }
         jumpCount = 0;


### PR DESCRIPTION
## 작업한 내용
- #19 
- 플레이어 점프 이슈 문제 파익 및 해결

## 참고 사항
- 점프 전후로 플레이어의 위치값(z값)이 일정하게 유지되지 않는 문제를 해결하였습니다.
- 기존의 점프 상승/하강은 아래와 같이 이동 방향에 `Time.deltaTime`을 곱하여 구현하였습니다.
   - 그러나, 이러한 방식은 프레임 속도에 따라 이동 정도가 달라질 수 있다는 문제를 갖고 있습니다.
```C#
playerBodyCharacterController.Move(new Vector3(0,0,2) * Time.deltaTime);
```
- 따라서, 프레임 속도에 영향받지 않고 플레이어가 고정된 크기만큼 점프를 할 수 있도록 코드를 아래와 같이 수정하였습니다.
   - `jumpWeight`: 점프 가중치
   - (0.03f는 임의의 값이므로, 추후에 기획팀과 논의하여 수정될 필요가 있습니다.)
```C#
var jumpWeight = 0.03f;
        
        while (jumpCount < 10)
        {
            jumpCount++;
            playerBodyCharacterController.Move(new Vector3(0,0,2) * jumpWeight);
            yield return new WaitForFixedUpdate();
        }
```

## 스크린샷
|기능|스크린샷|
|:--:|:--:|
|점프 이슈 해결|<img src = "https://github.com/alttabsoft/13-zodiac-signs/assets/97589973/5ded68ff-b8b5-4040-bf6b-6a222705f1f9"> (실제 점프는 속도는 해당 이미지보다 빠릅니다.)

## 관련 이슈
- Resolved: #19
