### PR TITLE
[FEAT] 병합된 브랜치 태그 후 자동 삭제 기능 추가 GITHUB ACTION

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,76 @@
+name: Check Merged Branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches : [main]
+
+jobs:
+  check_merged_branch:
+    runs-on: ubuntu-latest
+    # defaults:
+    #   run:
+    #     working-directory: ./.github/workflows/scripts
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref : ${{ github.event.pull_request.head.sha }}
+
+      # - name:
+      #   run: | 
+      #     chmod +x my-script.sh
+      #     ./my-script.sh
+
+      - name: Get merged branches
+        run: |
+          echo ${{ github.ref_name }}
+          echo ${{ github.event.pull_request.head.sha }}
+          echo ${{ github.sha }}
+
+      - name: have a tag
+        run: |
+          # git branch --contains ${{ github.event.pull_request.head.sha }}
+          git branch --contains ${{ github.sha }}
+          echo archive/${{github.head_ref}}
+
+      - name: create a tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"}
+
+          str1=$(git tag -l "archive/${{github.head_ref}}")
+          str2=""
+
+          if [[ "$str1" != "$str2" ]]; then
+              echo $str1" 은 이미 있는 태그명"
+              echo "루프 시작"
+              count=1
+              while true; do
+                  str1="archive/${{github.head_ref}}-""$count"
+                  str2=""
+                  result=$(git tag -l "$str1")
+                  echo $str1
+                  if [[ "$result" == "$str2" ]]; then
+                      echo "없는 태그명"
+                      echo "태깅 시작"
+                      echo "태그를 시작합니다."
+                      git tag -a "archive/${{github.head_ref}}-""$count" -m"" ${{github.head_ref}}
+                      git push origin "archive/${{github.head_ref}}-""$count"
+                      break
+                  fi
+                      echo "있는 태그명"
+                      ((count++))
+              done
+          else
+              echo "존재하지 않는 태그명"
+              echo "태그를 시작합니다."
+              echo archive/${{github.head_ref}}
+              git tag -a archive/${{github.head_ref}} -m"" ${{github.head_ref}}
+              git push origin archive/${{github.head_ref}}
+          fi
+        
+      - name: 브랜치 삭제
+        run: |
+          git push origin -d ${{github.head_ref}}

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -44,7 +44,7 @@ jobs:
           str2=""
 
           if [[ "$str1" != "$str2" ]]; then
-              echo $str1" 은 이미 있는 태그명"
+              echo $str1" 은 이미 있는 태그"
               echo "루프 시작"
               count=1
               while true; do
@@ -53,18 +53,18 @@ jobs:
                   result=$(git tag -l "$str1")
                   echo $str1
                   if [[ "$result" == "$str2" ]]; then
-                      echo "없는 태그명"
+                      echo "없는 태그"
                       echo "태깅 시작"
                       echo "태그를 시작합니다."
                       git tag -a "archive/${{github.head_ref}}-""$count" -m"" ${{github.head_ref}}
                       git push origin "archive/${{github.head_ref}}-""$count"
                       break
                   fi
-                      echo "있는 태그명"
+                      echo "있는 태그"
                       ((count++))
               done
           else
-              echo "존재하지 않는 태그명"
+              echo "존재하지 않는 태그"
               echo "태그를 시작합니다."
               echo archive/${{github.head_ref}}
               git tag -a archive/${{github.head_ref}} -m"" ${{github.head_ref}}


### PR DESCRIPTION
## 작업한 내용
### 이제 Develop 브랜치에 Squash merge 한 브랜치는 자동으로 태그 생성 후 삭제됩니다!

## 참고 사항
- 웹상에서 충돌을 해결할 경우 github desktop 에서 태그가 안보일 수 있습니다. 
- 이제 태그 창이 매우 지저분해질 수 있습니다.
- 동일한 브랜치에서 여러번 PR 을 날려서, 브랜치 하나에서 여러번 PR 이 닫히게 되면, **태그 뒤에 숫자가 늘어나는 식**으로 처리했습니다.
- **bash의 문법은 띄어쓰기를 매우 중요시 여깁니다.**

## 스크린샷
|기능|스크린샷|
|:--:|:--:|
|구현 예|<img src = "https://github.com/alttabsoft/13-zodiac-signs/assets/69492686/821bb704-0d0b-4ef5-a08d-5164ec72e420">
|구현 예|<img src = https://github.com/alttabsoft/13-zodiac-signs/assets/69492686/ab4be189-f01b-4d5a-b661-e5b4b6af29c7>



## 관련 이슈
- Resolved: #29 
