### PR TITLE
[FEAT] 맵 크기 증가, 카메라 캐릭터 추적 (#36)

### DIFF
--- a/Assets/Scenes/Rubik_BattleScene.unity
+++ b/Assets/Scenes/Rubik_BattleScene.unity
@@ -1120,7 +1120,7 @@ Transform:
   m_GameObject: {fileID: 320846683}
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: -1.87, y: 0.9, z: -5.01}
+  m_LocalPosition: {x: -0.06, y: 0.9, z: -5.01}
   m_LocalScale: {x: 0.54, y: 0.54, z: 0.54}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1363,7 +1363,7 @@ Transform:
   m_GameObject: {fileID: 367366447}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0.7071068, z: -0.7071068, w: 0}
-  m_LocalPosition: {x: -1.87, y: 0.89999, z: -5.301}
+  m_LocalPosition: {x: -0.059999943, y: 0.89999, z: -5.301}
   m_LocalScale: {x: 0.43000004, y: 0.43000004, z: 0.43000004}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -1407,6 +1407,7 @@ GameObject:
   - component: {fileID: 373038116}
   - component: {fileID: 373038115}
   - component: {fileID: 373038118}
+  - component: {fileID: 373038119}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1532,6 +1533,20 @@ MonoBehaviour:
     mipBias: 0
     varianceClampScale: 0.9
     contrastAdaptiveSharpening: 0
+--- !u!114 &373038119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373038114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 975cd5fc5e1da4b4bba01b3e0a159ba5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Cam: {fileID: 373038114}
+  Player: {fileID: 320846683}
 --- !u!1 &385383118
 GameObject:
   m_ObjectHideFlags: 0
@@ -3532,6 +3547,112 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1616831693}
   m_CullTransparentMesh: 1
+--- !u!1 &1618964585
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1618964589}
+  - component: {fileID: 1618964588}
+  - component: {fileID: 1618964587}
+  - component: {fileID: 1618964586}
+  m_Layer: 0
+  m_Name: Plane (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &1618964586
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1618964585}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1618964587
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1618964585}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d05746e74f921b843b18b204c53fe478, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1618964588
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1618964585}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1618964589
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1618964585}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 10.86, y: -0.59, z: -1.18}
+  m_LocalScale: {x: 1.1, y: 1.1, z: 1.1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &1804707174
 GameObject:
   m_ObjectHideFlags: 0
@@ -4646,6 +4767,7 @@ SceneRoots:
   - {fileID: 373038117}
   - {fileID: 237202545}
   - {fileID: 111375331}
+  - {fileID: 1618964589}
   - {fileID: 320846684}
   - {fileID: 367366449}
   - {fileID: 985451725}

--- a/Assets/Scenes/Rubik_TempAsset/Scripts/BattleCamController.cs
+++ b/Assets/Scenes/Rubik_TempAsset/Scripts/BattleCamController.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BattleCamController : MonoBehaviour
+{
+    [SerializeField] private GameObject Cam;
+    [SerializeField] private GameObject Shadow;
+
+    private Vector3 Gap;
+    
+    private void Start()
+    {
+        Gap = Cam.transform.position - Shadow.transform.position;
+    }
+
+    void FixedUpdate()
+    {
+        if (Shadow.transform.position.x > -0.15)
+        {
+            if (Shadow.transform.position.x < 10.05)
+            {
+                Cam.transform.position = new Vector3(Shadow.transform.position.x + Gap.x, Cam.transform.position.y, Cam.transform.position.z);
+            }
+        }
+    }
+}

--- a/Assets/Scenes/Rubik_TempAsset/Scripts/BattleCamController.cs.meta
+++ b/Assets/Scenes/Rubik_TempAsset/Scripts/BattleCamController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 975cd5fc5e1da4b4bba01b3e0a159ba5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 작업한 내용
- 카메라가 캐릭터의 그림자를 추적해서 움직입니다.
- 맵 크기를 키웠습니다.
- 캐릭터가 맵 테두리로 가면 카메라는 더 이상 캐릭터를 따라가지 않습니다.

## 참고 사항
- 맵 크기를 화면 사이즈의 n배로 정확하게 맞춰서 키우자니, 현재 디자인 에셋이 임시 에셋이라
에셋 크기가 확정되어야 정밀하게 맵 사이즈 조절이 가능해 보여 일단 기존 맵 크기를 2배로 늘렸습니다.

- 캐릭터 본체를 추적해서 움직이니 캐릭터가 점프하면 카메라도 같이 점프해서 그림자를 추적합니다

## 스크린샷
![map](https://github.com/alttabsoft/13-zodiac-signs/assets/67681580/054d8ee1-8a63-48bb-ae3a-a5631a0d0b3e)

## 관련 이슈
- Resolved: #36 
